### PR TITLE
Fixed a bug where Trees would merge incorrectly on case insensitive FSes

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ function TreeMerger (inputTrees, options) {
   this.options = options || {}
 }
 
+var toLowerCase = function (str) {
+  return str.toLowerCase()
+}
+
 TreeMerger.prototype.write = function (readTree, destDir) {
   var self = this
   var files = {}
@@ -24,6 +28,8 @@ TreeMerger.prototype.write = function (readTree, destDir) {
   return mapSeries(this.inputTrees, readTree).then(function (treePaths) {
     for (var i = treePaths.length - 1; i >= 0; i--) {
       var treeContents = walkSync(treePaths[i])
+      treeContents = treeContents.map(toLowerCase)
+
       var fileIndex
       for (var j = 0; j < treeContents.length; j++) {
         var relativePath = treeContents[j]

--- a/test/tree_merger_test.coffee
+++ b/test/tree_merger_test.coffee
@@ -34,6 +34,17 @@ test 'mergeTrees', (t) ->
     .catch (err) ->
       t.similar err.message, /file "bar" exists in .* and .* overwrite: true/
 
+  test 'file names should be treated case insensitive', (t) ->
+    t.plan 1
+
+    mergeFixtures [
+      foo: '1'
+    ,
+      Foo: '2'
+    ]
+    .catch (err) ->
+      t.similar err.message, /file "foo" exists in .* and .* overwrite: true/
+
   test 'accepts { overwrite: true }', (t) ->
     t.plan 1
     mergeFixtures [


### PR DESCRIPTION
OSX's filesystem is case insensitive, but broccoli-merge-trees's cache
currently caches files like HISTORY.md and History.md as separate
entries, which means that it incorrectly handles conflicts in the filesystem.

A potential (better) fix could be to determine this based on whether the
FS is case sensitive or not, but that would result in different
behaviour on different platforms which could lead to very subtle bugs.

Not sure if this fix should land in broccoli main or only here (since it
really affects merging trees, this seems like a sensible place).

I haven't been able to run the tests for this, because all tests fail as-is...
