### PR TITLE
Fix for file system case sensitivity

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,23 @@ TreeMerger.prototype.write = function (readTree, destDir) {
   var self = this
   var files = {}
   var directories = {}
+  var defaultRegexOpts = ['__MACOSX.+','.DS_Store','.bower.json']
+  var regexOpts = self.options.regFilter ?
+      self.options.regFilter.join('|')
+      :defaultRegexOpts.join('|')
+
+  function fileFilter (str) {
+    return str.match( new RegExp(regexOpts,'g') ) === null
+  }
+
   return mapSeries(this.inputTrees, readTree).then(function (treePaths) {
     for (var i = treePaths.length - 1; i >= 0; i--) {
       var treeContents = walkSync(treePaths[i])
+
+      if (regexOpts) {
+            treeContents = treeContents.filter(fileFilter)
+      }
+
       var fileIndex
       for (var j = 0; j < treeContents.length; j++) {
         var relativePath = treeContents[j]
@@ -43,7 +57,7 @@ TreeMerger.prototype.write = function (readTree, destDir) {
           if (directoryIndex != null) {
             throwFileAndDirectoryCollision(relativePath, i, directoryIndex)
           }
-          fileIndex = files[relativePath]
+          fileIndex = files[relativePath.toLowerCase()]
           if (fileIndex != null) {
             if (!self.options.overwrite) {
               throw new Error('Merge error: ' +
@@ -57,7 +71,7 @@ TreeMerger.prototype.write = function (readTree, destDir) {
           } else {
             helpers.copyPreserveSync(
               treePaths[i] + '/' + relativePath, destPath)
-            files[relativePath] = i
+            files[relativePath.toLowerCase()] = i
           }
         }
       }


### PR DESCRIPTION
Here is my proposed fix for the case sensitivity issue on Mac OS X and Linux. Tests pass.

I've also added in an option regexFilter to ignore certain files I don't think need processing.
mergeTrees([], {overwrite: true, regFilter:[]});

By default will ignore the following files / hidden directories:
"__MACOSX",
".DS_Store",
".bower.json"
