### PR TITLE
Use symlinks, and symlink entire subdirectories where possible instead of recursing

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,7 +12,7 @@
     "latedef"       : false,    // true: Require variables/functions to be defined before being used
     "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
     "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
-    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "noempty"       : false,    // true: Prohibit use of empty blocks
     "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
     "plusplus"      : false,    // true: Prohibit use of `++` & `--`
     "quotmark"      : true,     // Quotation mark consistency:
@@ -44,7 +44,7 @@
     "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
     "iterator"      : false,     // true: Tolerate using the `__iterator__` property
     "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
-    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+    "laxbreak"      : true,      // true: Tolerate possibly unsafe line breakings
     "laxcomma"      : false,     // true: Tolerate comma-first style coding
     "loopfunc"      : false,     // true: Tolerate functions being defined in loops
     "multistr"      : false,     // true: Tolerate multi-line strings

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 var fs = require('fs')
-var walkSync = require('walk-sync')
+var path = require('path')
 var Writer = require('broccoli-writer')
 var helpers = require('broccoli-kitchen-sink-helpers')
 var mapSeries = require('promise-map-series')
 
+var isWindows = process.platform === 'win32'
 
 module.exports = TreeMerger
 TreeMerger.prototype = Object.create(Writer.prototype)
@@ -19,54 +20,143 @@ function TreeMerger (inputTrees, options) {
 
 TreeMerger.prototype.write = function (readTree, destDir) {
   var self = this
-  var files = {}
-  var directories = {}
+
   return mapSeries(this.inputTrees, readTree).then(function (treePaths) {
-    for (var i = treePaths.length - 1; i >= 0; i--) {
-      var treeContents = walkSync(treePaths[i])
-      var fileIndex
-      for (var j = 0; j < treeContents.length; j++) {
-        var relativePath = treeContents[j]
-        var destPath = destDir + '/' + relativePath
-        if (relativePath.slice(-1) === '/') { // is directory
-          relativePath = relativePath.slice(0, -1) // chomp "/"
-          fileIndex = files[relativePath]
-          if (fileIndex != null) {
-            throwFileAndDirectoryCollision(relativePath, fileIndex, i)
-          }
-          if (directories[relativePath] == null) {
-            fs.mkdirSync(destPath)
-            directories[relativePath] = i
-          }
-        } else { // is file
-          var directoryIndex = directories[relativePath]
-          if (directoryIndex != null) {
-            throwFileAndDirectoryCollision(relativePath, i, directoryIndex)
-          }
-          fileIndex = files[relativePath.toLowerCase()]
-          if (fileIndex != null) {
-            if (!self.options.overwrite) {
-              throw new Error('Merge error: ' +
-                'file "' + relativePath + '" exists in ' +
-                treePaths[i] + ' and ' + treePaths[fileIndex] + ' - ' +
-                'pass option { overwrite: true } to mergeTrees in order ' +
-                'to have the latter file win')
+    mergeRelativePath('')
+
+    function mergeRelativePath (baseDir, possibleIndices) {
+      // baseDir has a trailing path.sep if non-empty
+      var i, j, fileName, fullPath
+
+      // Array of readdir arrays
+      var names = treePaths.map(function (treePath, i) {
+        if (possibleIndices == null || possibleIndices.indexOf(i) !== -1) {
+          return fs.readdirSync(treePath + path.sep + baseDir).sort()
+        } else {
+          return []
+        }
+      })
+
+      // Guard against conflicting capitalizations
+      var lowerCaseNames = {}
+      for (i = 0; i < treePaths.length; i++) {
+        for (j = 0; j < names[i].length; j++) {
+          fileName = names[i][j]
+          var lowerCaseName = fileName.toLowerCase()
+          if (lowerCaseNames[lowerCaseName] == null) {
+            lowerCaseNames[lowerCaseName] = {
+              index: i,
+              originalName: fileName
             }
-            // Else, ignore this file. It is "overwritten" by a file we copied
-            // earlier, thanks to reverse iteration over trees
           } else {
-            helpers.copyPreserveSync(
-              treePaths[i] + '/' + relativePath, destPath)
-            files[relativePath.toLowerCase()] = i
+            var originalIndex = lowerCaseNames[lowerCaseName].index
+            var originalName = lowerCaseNames[lowerCaseName].originalName
+            if (originalName !== fileName) {
+              throw new Error('Merge error: conflicting capitalizations:\n'
+                + baseDir + originalName + ' in ' + treePaths[originalIndex] + '\n'
+                + baseDir + fileName + ' in ' + treePaths[i] + '\n'
+                + 'Remove one of the files and re-add it with matching capitalization.\n'
+                + 'We are strict about this to avoid divergent behavior '
+                + 'between case-insensitive Mac/Windows and case-sensitive Linux.'
+              )
+            }
+          }
+        }
+      }
+      // From here on out, no files and directories exist with conflicting
+      // capitalizations, which means we can use `===` without .toLowerCase
+      // normalization.
+
+      // Accumulate fileInfo hashes of { isDirectory, indices }.
+      // Also guard against conflicting file types and overwriting.
+      var fileInfo = {}
+      for (i = 0; i < treePaths.length; i++) {
+        for (j = 0; j < names[i].length; j++) {
+          fileName = names[i][j]
+          fullPath = treePaths[i] + path.sep + baseDir + fileName
+          var isDirectory = checkIsDirectory(fullPath)
+          if (fileInfo[fileName] == null) {
+            fileInfo[fileName] = {
+              isDirectory: isDirectory,
+              indices: [i] // indices into treePaths in which this file exists
+            }
+          } else {
+            fileInfo[fileName].indices.push(i)
+
+            // Guard against conflicting file types
+            var originallyDirectory = fileInfo[fileName].isDirectory
+            if (originallyDirectory !== isDirectory) {
+              throw new Error('Merge error: conflicting file types: ' + baseDir + fileName
+                + ' is a ' + (originallyDirectory ? 'directory' : 'file')
+                  + ' in ' + treePaths[fileInfo[fileName].indices[0]]
+                + ' but a ' + (isDirectory ? 'directory' : 'file')
+                  + ' in ' + treePaths[i] + '\n'
+                + 'Remove or rename either of those.'
+              )
+            }
+
+            // Guard against overwriting when disabled
+            if (!isDirectory && !self.options.overwrite) {
+              throw new Error('Merge error: '
+                + 'file ' + baseDir + fileName + ' exists in '
+                + treePaths[fileInfo[fileName].indices[0]] + ' and ' + treePaths[i] + '\n'
+                + 'Pass option { overwrite: true } to mergeTrees in order '
+                + 'to have the latter file win.'
+              )
+            }
+          }
+        }
+      }
+
+      // Done guarding against all error conditions. Actually merge now.
+      for (i = 0; i < treePaths.length; i++) {
+        for (j = 0; j < names[i].length; j++) {
+          fileName = names[i][j]
+          fullPath = treePaths[i] + path.sep + baseDir + fileName
+          var destPath = destDir + path.sep + baseDir + fileName
+          var infoHash = fileInfo[fileName]
+
+          if (infoHash.isDirectory) {
+            if (isWindows || infoHash.indices.length > 1) {
+              // Copy/merge subdirectory
+              if (infoHash.indices[0] === i) { // avoid duplicate recursion
+                fs.mkdirSync(destPath)
+                mergeRelativePath(baseDir + fileName + path.sep, infoHash.indices)
+              }
+            } else {
+              // Symlink entire subdirectory
+              if (fs.lstatSync(fullPath).isSymbolicLink()) {
+                // When we encounter symlinks, follow them. This prevents indirection
+                // from growing out of control. Note: At the moment `realpath` on Node
+                // is 70x slower than native: https://github.com/joyent/node/issues/7902
+                fullPath = fs.realpathSync(fullPath)
+              } else if (fullPath[0] !== path.sep) {
+                fullPath = process.cwd() + path.sep + fullPath
+              }
+              fs.symlinkSync(fullPath, destPath)
+            }
+          } else { // isFile
+            if (infoHash.indices[infoHash.indices.length-1] === i) {
+              helpers.symlinkOrCopyPreserveSync(fullPath, destPath)
+            } else {
+              // This file exists in a later tree. Do nothing here to have the
+              // later file win out and thus "overwrite" the earlier file.
+            }
           }
         }
       }
     }
-
-    function throwFileAndDirectoryCollision (relativePath, fileIndex, directoryIndex) {
-      throw new Error('Merge error: "' + relativePath +
-        '" exists as a file in ' + treePaths[fileIndex] +
-        ' but as a directory in ' + treePaths[directoryIndex])
-    }
   })
+}
+
+// True if directory, false if file, exception otherwise
+function checkIsDirectory (fullPath) {
+  var stat = fs.statSync(fullPath) // may throw ENOENT on broken symlink
+  if (stat.isDirectory()) {
+    return true
+  } else if (stat.isFile()) {
+    return false
+  } else {
+    throw new Error('Unexpected file type for ' + fullPath)
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
   ],
   "dependencies": {
     "promise-map-series": "^0.2.0",
-    "walk-sync": "^0.1.2",
     "broccoli-writer": "^0.1.1",
-    "broccoli-kitchen-sink-helpers": "^0.2.0"
+    "broccoli-kitchen-sink-helpers": "~0.2.3"
   },
   "devDependencies": {
-    "tap": "^0.4.8",
-    "rsvp": "^3.0.6",
+    "coffee-script": "~1.7.1",
     "fixturify": "^0.1.1",
     "jshint": "~2.5.0",
-    "coffee-script": "~1.7.1"
+    "ncp": "^0.6.0",
+    "rsvp": "^3.0.6",
+    "tap": "^0.4.8"
   },
   "scripts": {
     "test": "jshint *.js test/*.js && tap --stderr --timeout 2 ./test/*_test.coffee"


### PR DESCRIPTION
This greatly improves performance.

This change in the algorithm also cleans up some capitalization edge
cases. We now always throw an error when we encounter inconsistent
capitalization, which ensures consistent behavior between case-sensitive
and case-insensitive file systems.

---

@rjackson, I don't think the history on the symlink branch is terribly meaningful at this point, so I've squashed the symlink branch into a single commit with shared authorship. I re-read the diff and it looks fine to me.

Is there anything else we need to think about before we merge this into master? I can't think of anything off the top of my head.

Hit the merge button if you feel good about this. :)
