### PR TITLE
Explicitly state that parent dirs are not included

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ module.exports = mergeTrees(['public', 'scripts']);
 
 And your project contains these files:
 
-    public
-    ├─ index.html
-    └─ images
-       └─ logo.png
-    scripts
-    └─ app.js
-    Brocfile.js
+    .
+    ├─ public
+    │  ├─ index.html
+    │  └─ images
+    │     └─ logo.png
+    ├─ scripts
+    │  └─ app.js
+    ├─ Brocfile.js
     …
 
 Then running `broccoli build the-output` will generate this folder:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Then running `broccoli build the-output` will generate this folder:
     └─ images
        └─ logo.png
 
+The parent folders, `public` and `scripts` in this case, are not included in the output. The output tree contains only the files *within* each folder, all mixed together.
+
 ## Contributing
 
 Clone this repo and run the tests like so:


### PR DESCRIPTION
The example demonstrates this, but people have to do mental diffing of the inputs and outputs to determine this. Stating it directly should save people time.