### PR TITLE
Combine tree merging

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,19 @@ function BroccoliMergeTrees(inputNodes, options) {
     throw new Error('Expected array, got ' + inputNodes)
   }
   options = options || {}
-  Plugin.call(this, inputNodes, {
+  var newInputNodes = []
+  for (var i = 0 ; i < inputNodes.length ; i++ ) {
+    if (inputNodes[i].constructor.name  === this.constructor.name ) {
+
+      for (var j = 0; j < inputNodes[i]._inputNodes.length; j++) {
+        newInputNodes.push(inputNodes[i]._inputNodes[j]);
+      }
+    }
+    else {
+      newInputNodes.push(inputNodes[i]);
+    }
+  }
+  Plugin.call(this, newInputNodes, {
     annotation: options.annotation
   })
 


### PR DESCRIPTION
This PR try to combine the tree merging operation when input Nodes is also a merge tree node. Seem a ugly hack, but this reduce number of tmp folder a lot in an ember-cli application and  reduce the intial build time from 40s to around 35s  for me  on windows.
