### PR TITLE
Merge using fs tree diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 test/tmp
+/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 test/tmp
-/

--- a/entry.js
+++ b/entry.js
@@ -6,4 +6,9 @@ function Entry(relativePath, basePath, mode, size, mtime) {
   this.mtime = mtime;
 }
 
+
+Entry.prototype.isDirectory = function() {
+  return (this.mode & 61440) === 16384;
+};
+
 module.exports = Entry;

--- a/entry.js
+++ b/entry.js
@@ -1,14 +1,12 @@
 function Entry(relativePath, basePath, mode, size, mtime) {
   this.mode = mode;
 
-  if (this.isDirectory() && relativePath.charAt(relativePath.length - 1) !== '/') {
-    relativePath += '/';
-  }
-
   this.relativePath = relativePath;
   this.basePath = basePath;
   this.size = size;
   this.mtime = mtime;
+
+  this.linkDir = false;
 }
 
 

--- a/entry.js
+++ b/entry.js
@@ -1,13 +1,19 @@
 function Entry(relativePath, basePath, mode, size, mtime) {
+  this.mode = mode;
+
+  if (this.isDirectory() && relativePath.charAt(relativePath.length - 1) !== '/') {
+    relativePath += '/';
+  }
+
   this.relativePath = relativePath;
   this.basePath = basePath;
-  this.mode = mode;
   this.size = size;
   this.mtime = mtime;
 }
 
 
 Entry.prototype.isDirectory = function() {
+  /*jshint -W016 */
   return (this.mode & 61440) === 16384;
 };
 

--- a/entry.js
+++ b/entry.js
@@ -1,0 +1,9 @@
+function Entry(relativePath, basePath, mode, size, mtime) {
+  this.relativePath = relativePath;
+  this.basePath = basePath;
+  this.mode = mode;
+  this.size = size;
+  this.mtime = mtime;
+}
+
+module.exports = Entry;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var fs = require('fs')
 var Plugin = require('broccoli-plugin')
 var symlinkOrCopySync = require('symlink-or-copy').sync
 var debug = require('debug')
+var Set = require('fast-ordered-set');
+var FSTree = require('fs-tree-diff');
 
 module.exports = BroccoliMergeTrees
 BroccoliMergeTrees.prototype = Object.create(Plugin.prototype)
@@ -20,6 +22,7 @@ function BroccoliMergeTrees(inputNodes, options) {
   this._debug = debug(name);
   this.options = options
   this._buildCount = 0;
+  this._currentTree = FSTree.fromPaths([]);
 }
 
 BroccoliMergeTrees.prototype.debug = function(message, args) {
@@ -27,136 +30,156 @@ BroccoliMergeTrees.prototype.debug = function(message, args) {
 }
 
 BroccoliMergeTrees.prototype.build = function() {
-  var inputPaths = this.inputPaths
-  var outputPath = this.outputPath
-  var overwrite = this.options.overwrite
   this._buildCount++;
 
   var start = new Date()
-  mergeRelativePath('')
+
+  var sourceMap = new Set();
+  var newEntries = this._mergeRelativePath('', null, sourceMap); 
+  var newTree = FSTree.fromEntries(newEntries);
+  var patch = this.currentTree.calculatePatch(newTree);
+  this.currentTree = newTree;
+  this._applyPatch(patch);
+
+
   this.debug('build: \n %o', {
     count: this._buildCount,
     in: new Date() - start + 'ms'
   })
+}
 
-  function mergeRelativePath (baseDir, possibleIndices) {
-    // baseDir has a trailing path.sep if non-empty
-    var i, j, fileName, fullPath
+BroccoliMergeTrees.prototype._applyPatch = function (patch, sourceMapping) {
+  // ∀ p ϵ patch
+  //  apply p (create, link &c.)
+};
 
-    // Array of readdir arrays
-    var names = inputPaths.map(function (inputPath, i) {
-      if (possibleIndices == null || possibleIndices.indexOf(i) !== -1) {
-        return fs.readdirSync(inputPath + '/' + baseDir).sort()
+BroccoliMergeTrees.prototype._mergeRelativePath = function (baseDir, possibleIndices, sourceMapping, entries) {
+  var inputPaths = this.inputPaths;
+  var outputPath = this.outputPath;
+  var overwrite = this.options.overwrite;
+  if (! entries) { entries = new Set(); }
+
+  // baseDir has a trailing path.sep if non-empty
+  var i, j, fileName, fullPath
+
+  // Array of readdir arrays
+  var names = inputPaths.map(function (inputPath, i) {
+    if (possibleIndices == null || possibleIndices.indexOf(i) !== -1) {
+      return fs.readdirSync(inputPath + '/' + baseDir).sort()
+    } else {
+      return []
+    }
+  })
+
+  // Guard against conflicting capitalizations
+  var lowerCaseNames = {}
+  for (i = 0; i < inputPaths.length; i++) {
+    for (j = 0; j < names[i].length; j++) {
+      fileName = names[i][j]
+      var lowerCaseName = fileName.toLowerCase()
+      // Note: We are using .toLowerCase to approximate the case
+      // insensitivity behavior of HFS+ and NTFS. While .toLowerCase is at
+      // least Unicode aware, there are probably better-suited functions.
+      if (lowerCaseNames[lowerCaseName] == null) {
+        lowerCaseNames[lowerCaseName] = {
+          index: i,
+          originalName: fileName
+        }
       } else {
-        return []
-      }
-    })
-
-    // Guard against conflicting capitalizations
-    var lowerCaseNames = {}
-    for (i = 0; i < inputPaths.length; i++) {
-      for (j = 0; j < names[i].length; j++) {
-        fileName = names[i][j]
-        var lowerCaseName = fileName.toLowerCase()
-        // Note: We are using .toLowerCase to approximate the case
-        // insensitivity behavior of HFS+ and NTFS. While .toLowerCase is at
-        // least Unicode aware, there are probably better-suited functions.
-        if (lowerCaseNames[lowerCaseName] == null) {
-          lowerCaseNames[lowerCaseName] = {
-            index: i,
-            originalName: fileName
-          }
-        } else {
-          var originalIndex = lowerCaseNames[lowerCaseName].index
-          var originalName = lowerCaseNames[lowerCaseName].originalName
-          if (originalName !== fileName) {
-            throw new Error('Merge error: conflicting capitalizations:\n'
-              + baseDir + originalName + ' in ' + inputPaths[originalIndex] + '\n'
-              + baseDir + fileName + ' in ' + inputPaths[i] + '\n'
-              + 'Remove one of the files and re-add it with matching capitalization.\n'
-              + 'We are strict about this to avoid divergent behavior '
-              + 'between case-insensitive Mac/Windows and case-sensitive Linux.'
-            )
-          }
-        }
-      }
-    }
-    // From here on out, no files and directories exist with conflicting
-    // capitalizations, which means we can use `===` without .toLowerCase
-    // normalization.
-
-    // Accumulate fileInfo hashes of { isDirectory, indices }.
-    // Also guard against conflicting file types and overwriting.
-    var fileInfo = {}
-    for (i = 0; i < inputPaths.length; i++) {
-      for (j = 0; j < names[i].length; j++) {
-        fileName = names[i][j]
-        fullPath = inputPaths[i] + '/' + baseDir + fileName
-        var isDirectory = checkIsDirectory(fullPath)
-        if (fileInfo[fileName] == null) {
-          fileInfo[fileName] = {
-            isDirectory: isDirectory,
-            indices: [i] // indices into inputPaths in which this file exists
-          }
-        } else {
-          fileInfo[fileName].indices.push(i)
-
-          // Guard against conflicting file types
-          var originallyDirectory = fileInfo[fileName].isDirectory
-          if (originallyDirectory !== isDirectory) {
-            throw new Error('Merge error: conflicting file types: ' + baseDir + fileName
-              + ' is a ' + (originallyDirectory ? 'directory' : 'file')
-                + ' in ' + inputPaths[fileInfo[fileName].indices[0]]
-              + ' but a ' + (isDirectory ? 'directory' : 'file')
-                + ' in ' + inputPaths[i] + '\n'
-              + 'Remove or rename either of those.'
-            )
-          }
-
-          // Guard against overwriting when disabled
-          if (!isDirectory && !overwrite) {
-            throw new Error('Merge error: '
-              + 'file ' + baseDir + fileName + ' exists in '
-              + inputPaths[fileInfo[fileName].indices[0]] + ' and ' + inputPaths[i] + '\n'
-              + 'Pass option { overwrite: true } to mergeTrees in order '
-              + 'to have the latter file win.'
-            )
-          }
-        }
-      }
-    }
-
-    // Done guarding against all error conditions. Actually merge now.
-    for (i = 0; i < inputPaths.length; i++) {
-      for (j = 0; j < names[i].length; j++) {
-        fileName = names[i][j]
-        fullPath = inputPaths[i] + '/' + baseDir + fileName
-        var destPath = outputPath + '/' + baseDir + fileName
-        var infoHash = fileInfo[fileName]
-
-        if (infoHash.isDirectory) {
-          if (infoHash.indices.length > 1) {
-            // Copy/merge subdirectory
-            if (infoHash.indices[0] === i) { // avoid duplicate recursion
-              fs.mkdirSync(destPath)
-              mergeRelativePath(baseDir + fileName + '/', infoHash.indices)
-            }
-          } else {
-            // Symlink entire subdirectory
-            symlinkOrCopySync(fullPath, destPath)
-          }
-        } else { // isFile
-          if (infoHash.indices[infoHash.indices.length-1] === i) {
-            symlinkOrCopySync(fullPath, destPath)
-          } else {
-            // This file exists in a later inputPath. Do nothing here to have the
-            // later file win out and thus "overwrite" the earlier file.
-          }
+        var originalIndex = lowerCaseNames[lowerCaseName].index
+        var originalName = lowerCaseNames[lowerCaseName].originalName
+        if (originalName !== fileName) {
+          throw new Error('Merge error: conflicting capitalizations:\n'
+            + baseDir + originalName + ' in ' + inputPaths[originalIndex] + '\n'
+            + baseDir + fileName + ' in ' + inputPaths[i] + '\n'
+            + 'Remove one of the files and re-add it with matching capitalization.\n'
+            + 'We are strict about this to avoid divergent behavior '
+            + 'between case-insensitive Mac/Windows and case-sensitive Linux.'
+          )
         }
       }
     }
   }
-}
+  // From here on out, no files and directories exist with conflicting
+  // capitalizations, which means we can use `===` without .toLowerCase
+  // normalization.
+
+  // Accumulate fileInfo hashes of { isDirectory, indices }.
+  // Also guard against conflicting file types and overwriting.
+  var fileInfo = {}
+  for (i = 0; i < inputPaths.length; i++) {
+    for (j = 0; j < names[i].length; j++) {
+      fileName = names[i][j]
+      fullPath = inputPaths[i] + '/' + baseDir + fileName
+      var isDirectory = checkIsDirectory(fullPath)
+      if (fileInfo[fileName] == null) {
+        fileInfo[fileName] = {
+          isDirectory: isDirectory,
+          indices: [i] // indices into inputPaths in which this file exists
+        }
+      } else {
+        fileInfo[fileName].indices.push(i)
+
+        // Guard against conflicting file types
+        var originallyDirectory = fileInfo[fileName].isDirectory
+        if (originallyDirectory !== isDirectory) {
+          throw new Error('Merge error: conflicting file types: ' + baseDir + fileName
+            + ' is a ' + (originallyDirectory ? 'directory' : 'file')
+              + ' in ' + inputPaths[fileInfo[fileName].indices[0]]
+            + ' but a ' + (isDirectory ? 'directory' : 'file')
+              + ' in ' + inputPaths[i] + '\n'
+            + 'Remove or rename either of those.'
+          )
+        }
+
+        // Guard against overwriting when disabled
+        if (!isDirectory && !overwrite) {
+          throw new Error('Merge error: '
+            + 'file ' + baseDir + fileName + ' exists in '
+            + inputPaths[fileInfo[fileName].indices[0]] + ' and ' + inputPaths[i] + '\n'
+            + 'Pass option { overwrite: true } to mergeTrees in order '
+            + 'to have the latter file win.'
+          )
+        }
+      }
+    }
+  }
+
+  // Done guarding against all error conditions. Actually merge now.
+  for (i = 0; i < inputPaths.length; i++) {
+    for (j = 0; j < names[i].length; j++) {
+      fileName = names[i][j]
+      fullPath = inputPaths[i] + '/' + baseDir + fileName
+      var destPath = outputPath + '/' + baseDir + fileName
+      var infoHash = fileInfo[fileName]
+
+      if (infoHash.isDirectory) {
+        if (infoHash.indices.length > 1) {
+          // Copy/merge subdirectory
+          if (infoHash.indices[0] === i) { // avoid duplicate recursion
+          // TODO: add to entries
+            fs.mkdirSync(destPath)
+            this._mergeRelativePath(baseDir + fileName + '/', infoHash.indices, sourceMapping)
+          }
+        } else {
+          // TODO: add to entries
+          // Symlink entire subdirectory
+          symlinkOrCopySync(fullPath, destPath)
+        }
+      } else { // isFile
+        if (infoHash.indices[infoHash.indices.length-1] === i) {
+          // TODO: add to entries
+          symlinkOrCopySync(fullPath, destPath)
+        } else {
+          // This file exists in a later inputPath. Do nothing here to have the
+          // later file win out and thus "overwrite" the earlier file.
+        }
+      }
+    }
+  }
+
+  return entries;
+};
 
 // True if directory, false if file, exception otherwise
 function checkIsDirectory (fullPath) {

--- a/index.js
+++ b/index.js
@@ -91,7 +91,10 @@ BroccoliMergeTrees.prototype._applyPatch = function (patch) {
     var outputFilePath = this.outputPath + '/' + relativePath;
     var inputFilePath = entry && entry.basePath + '/' + relativePath;
 
-    this.debug('operation: %s relativePath: %s entry: %o', operation, relativePath, entry);
+    this.debug('%o', {
+       operation: operation,
+       entry:entry
+    });
 
     switch(operation) {
       case 'linkdir':   return symlinkOrCopySync(inputFilePath, outputFilePath);

--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@ var debug = require('debug')
 var FSTree = require('fs-tree-diff');
 var Entry = require('./entry');
 
-var isWindows = process.platform === 'win32'
-var canSymlink = ! isWindows;
+var canSymlink = require('can-symlink')();
 
 function unlinkOrRmrfSync(path) {
   if (canSymlink) {

--- a/index.js
+++ b/index.js
@@ -63,10 +63,10 @@ BroccoliMergeTrees.prototype.build = function() {
 
   this._currentTree = newTree;
 
-  var applyPatch = new Date();
+  var applyPatchStart = new Date();
 
   this._applyPatch(patch);
-  var applyPatchTime = new Date() - applyPatch + 'ms';
+  var applyPatchTime = new Date() - applyPatchStart + 'ms';
 
   this.debug('build: \n %o', {
     count: this._buildCount,

--- a/index.js
+++ b/index.js
@@ -91,6 +91,8 @@ BroccoliMergeTrees.prototype._applyPatch = function (patch) {
     var outputFilePath = this.outputPath + '/' + relativePath;
     var inputFilePath = entry && entry.basePath + '/' + relativePath;
 
+    this.debug('operation: %s relativePath: %s entry: %o', operation, relativePath, entry);
+
     switch(operation) {
       case 'linkdir':   return symlinkOrCopySync(inputFilePath, outputFilePath);
       case 'mkdir':     return fs.mkdirSync(outputFilePath);

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ BroccoliMergeTrees.prototype._applyPatch = function (patch) {
       case 'rmdir':     return fs.rmdirSync(outputFilePath);
       case 'unlink':    return fs.unlinkSync(outputFilePath);
       case 'unlinkdir': return unlinkOrRmrfSync(outputFilePath);
-      case 'create': return symlinkOrCopySync(inputFilePath, outputFilePath);
+      case 'create':    return symlinkOrCopySync(inputFilePath, outputFilePath);
       case 'update':
         fs.unlinkSync(outputFilePath);
         return symlinkOrCopySync(inputFilePath, outputFilePath);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mocha-jshint": "^2.2.5"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "test:debug": "mocha debug"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "broccoli-plugin": "^1.0.0",
     "debug": "^2.2.0",
     "fast-ordered-set": "^1.0.2",
-    "fs-tree-diff": "^0.3.0",
+    "fs-tree-diff": "git+https://github.com/stefanpenner/fs-tree-diff.git",
     "rimraf": "^2.4.3",
     "symlink-or-copy": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "can-symlink": "0.0.1",
     "debug": "^2.2.0",
     "fast-ordered-set": "^1.0.2",
-    "fs-tree-diff": "^0.4.0",
+    "fs-tree-diff": "^0.4.3",
     "rimraf": "^2.4.3",
     "symlink-or-copy": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "debug": "^2.2.0",
     "fast-ordered-set": "^1.0.2",
     "fs-tree-diff": "^0.3.0",
+    "rimraf": "^2.4.3",
     "symlink-or-copy": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "dependencies": {
     "broccoli-plugin": "^1.0.0",
     "debug": "^2.2.0",
+    "fast-ordered-set": "^1.0.2",
+    "fs-tree-diff": "^0.3.0",
     "symlink-or-copy": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "broccoli-plugin": "^1.0.0",
     "debug": "^2.2.0",
     "fast-ordered-set": "^1.0.2",
-    "fs-tree-diff": "git+https://github.com/stefanpenner/fs-tree-diff.git",
+    "fs-tree-diff": "^0.4.0",
     "rimraf": "^2.4.3",
     "symlink-or-copy": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "broccoli-plugin": "^1.0.0",
+    "can-symlink": "0.0.1",
     "debug": "^2.2.0",
     "fast-ordered-set": "^1.0.2",
     "fs-tree-diff": "^0.4.0",

--- a/test.js
+++ b/test.js
@@ -2,7 +2,6 @@ var MergeTrees = require('./')
 var chai = require('chai'), expect = chai.expect
 var chaiAsPromised = require('chai-as-promised'); chai.use(chaiAsPromised)
 var fixture = require('broccoli-fixture')
-var Set = require('fast-ordered-set');
 
 function mergeFixtures(inputFixtures, options) {
   return fixture.build(new MergeTrees(inputFixtures.map(function(obj) {

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ var MergeTrees = require('./')
 var chai = require('chai'), expect = chai.expect
 var chaiAsPromised = require('chai-as-promised'); chai.use(chaiAsPromised)
 var fixture = require('broccoli-fixture')
+var Set = require('fast-ordered-set');
 
 function mergeFixtures(inputFixtures, options) {
   return fixture.build(new MergeTrees(inputFixtures.map(function(obj) {
@@ -10,6 +11,23 @@ function mergeFixtures(inputFixtures, options) {
 }
 
 describe('MergeTrees', function() {
+  describe('_mergeRelativePaths', function() {
+    it.only('returns a set of entries', function() {
+      console.log(__dirname + '/tests/fixtures/a');
+      // TODO: this doesn't seem to set inputPaths; unclear how inputPaths is
+      // set b/c right now i can't get node debug to actually break anywhere
+      var mergeTrees = new MergeTrees([__dirname + '/tests/fixtures/a'], {
+        include: ['**/*.js'],
+      });
+      expect(mergeTrees._mergeRelativePath('', null, new Set())).to.deep.equal([
+        'something'
+      ]);
+    });
+  });
+
+  describe('_applyPatch', function() {
+  });
+
   it('merges files', function() {
     return expect(mergeFixtures([
       {
@@ -64,7 +82,7 @@ describe('MergeTrees', function() {
         }, {
           Foo: content
         }
-      ], options)).to.be.rejectedWith(/Merge error: conflicting capitalizations:\nFOO in .*\nFoo in .*\nRemove/)
+      ], options)).to.not.be.rejectedWith(/Merge error: conflicting capitalizations:\nFOO in .*\nFoo in .*\nRemove/)
     }
 
     return expectItToRefuseConflictingCapitalizations('file', { overwrite: false })

--- a/test.js
+++ b/test.js
@@ -10,17 +10,25 @@ function mergeFixtures(inputFixtures, options) {
   }), options))
 }
 
+function mapBy(array, property) {
+  return array.map(function (item) {
+    return item[property];
+  });
+}
+
 describe('MergeTrees', function() {
   describe('_mergeRelativePaths', function() {
-    it.only('returns a set of entries', function() {
-      console.log(__dirname + '/tests/fixtures/a');
-      // TODO: this doesn't seem to set inputPaths; unclear how inputPaths is
-      // set b/c right now i can't get node debug to actually break anywhere
-      var mergeTrees = new MergeTrees([__dirname + '/tests/fixtures/a'], {
-        include: ['**/*.js'],
-      });
-      expect(mergeTrees._mergeRelativePath('', null, new Set())).to.deep.equal([
-        'something'
+    it('returns an array of file infos', function() {
+      var mergeTrees = new MergeTrees([]);
+      mergeTrees.inputPaths = [__dirname + '/tests/fixtures/a'];
+      mergeTrees.outputPath = __dirname + '/tmp/output';
+
+      var fileInfos = mergeTrees._mergeRelativePath('');
+      var entries = mapBy(fileInfos, 'entry');
+
+      expect(mapBy(entries, 'relativePath')).to.deep.equal([
+        'bar.js',
+        'foo.js',
       ]);
     });
   });
@@ -82,7 +90,7 @@ describe('MergeTrees', function() {
         }, {
           Foo: content
         }
-      ], options)).to.not.be.rejectedWith(/Merge error: conflicting capitalizations:\nFOO in .*\nFoo in .*\nRemove/)
+      ], options)).to.be.rejectedWith(/Merge error: conflicting capitalizations:\nFOO in .*\nFoo in .*\nRemove/)
     }
 
     return expectItToRefuseConflictingCapitalizations('file', { overwrite: false })


### PR DESCRIPTION
- [x] release + use latest fs-tree-diff
- [x] fix canSymlink check
- [x] confirm in some more real world apps.
- [x] test real world apps on windows

----

bellow is Ember.js broccoli rebuild, it is an example of a project that has excessive number of merge-trees. It really should be refactored to avoid this many, but for now it serves a good stress test for merges.

![ember-rebuild](https://cloud.githubusercontent.com/assets/1377/11025020/16b82418-864b-11e5-95ab-29888f59195c.png)


before:

```
➜  ember.js git:(master) ✗ file changed debug.js

Build successful - 788ms.

Slowest Trees                                 | Total
----------------------------------------------+---------------------
BroccoliMergeTrees                            | 96ms
BroccoliMergeTrees                            | 69ms
BroccoliMergeTrees                            | 63ms
Babel                                         | 53ms
BroccoliMergeTrees                            | 49ms
SimpleReplace                                 | 42ms

Slowest Trees (cumulative)                    | Total (avg)
----------------------------------------------+---------------------
BroccoliMergeTrees (34)                       | 486ms (14 ms)
Babel (19)                                    | 82ms (4 ms)
SimpleReplace (5)                             | 67ms (13 ms)
ConcatWithMaps (8)                            | 47ms (5 ms)
Funnel (51)                                   | 41ms (0 ms)
```

after

```
➜  ember.js git:(master) ✗ file changed debug.js

Build successful - 342ms.

Slowest Trees                                 | Total
----------------------------------------------+---------------------
Babel                                         | 37ms
SimpleReplace                                 | 30ms
ConcatWithMaps                                | 27ms

Slowest Trees (cumulative)                    | Total (avg)
----------------------------------------------+---------------------
BroccoliMergeTrees (34)                       | 78ms (2 ms)
Babel (19)                                    | 57ms (3 ms)
SimpleReplace (5)                             | 53ms (10 ms)
ConcatWithMaps (8)                            | 42ms (5 ms)
Funnel (51)                                   | 35ms (0 ms)
JSHinter (30)                                 | 29ms (0 ms)
 (30)                                         | 23ms (0 ms)

```

@hjdivad & @stefanpenner 

----

This also got one of our large apps (200kloc of app.js code + 10k less + addons + vendor) from 800/900ms to 450ms rebuilds