### PR TITLE
Upgrade to can-symlink 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "broccoli-plugin": "^1.0.0",
-    "can-symlink": "0.0.1",
+    "can-symlink": "^1.0.0",
     "debug": "^2.2.0",
     "fast-ordered-set": "^1.0.2",
     "fs-tree-diff": "^0.4.3",


### PR DESCRIPTION
Fixes race condition in multiprocess environment (raytiley/can-symlink#3).