### PR TITLE
Adaptation of @tsing80’s node joining merge tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@ var fs = require('fs')
 var Plugin = require('broccoli-plugin')
 var symlinkOrCopySync = require('symlink-or-copy').sync
 var debug = require('debug')
+var ASSIMILATION_SYMBOL = 'broccoli-merge-tree@1.0.0';
 
 module.exports = BroccoliMergeTrees
 BroccoliMergeTrees.prototype = Object.create(Plugin.prototype)
 BroccoliMergeTrees.prototype.constructor = BroccoliMergeTrees
+
 function BroccoliMergeTrees(inputNodes, options) {
   if (!(this instanceof BroccoliMergeTrees)) return new BroccoliMergeTrees(inputNodes, options)
   options = options || {}
@@ -13,14 +15,37 @@ function BroccoliMergeTrees(inputNodes, options) {
   if (!Array.isArray(inputNodes)) {
     throw new TypeError(name + ': Expected array, got: [' + inputNodes +']')
   }
-  Plugin.call(this, inputNodes, {
+
+  Plugin.call(this, joinNodes(this, options, inputNodes), {
     annotation: options.annotation
-  })
+  });
 
   this._debug = debug(name);
   this.options = options
   this._buildCount = 0;
 }
+
+function joinNodes(host, options, inputNodes) {
+  var nodes = []
+  for (var i = 0 ; i < inputNodes.length ; i++ ) {
+    var node = inputNodes[i];
+    if (host[ASSIMILATION_SYMBOL](options, node)) {
+      for (var j = 0; j < inputNodes[i]._inputNodes.length; j++) {
+        nodes.push(inputNodes[i]._inputNodes[j]);
+      }
+    }
+    else {
+      nodes.push(inputNodes[i]);
+    }
+  }
+
+  return nodes;
+}
+
+BroccoliMergeTrees.prototype[ASSIMILATION_SYMBOL] = function(options, other) {
+  return typeof other[ASSIMILATION_SYMBOL] === 'function' &&
+         options.overwite === other.options.overwite;
+};
 
 BroccoliMergeTrees.prototype.debug = function(message, args) {
   this._debug(message, args);


### PR DESCRIPTION
- [x] merge with semver aware protocol
- [x] merge only if overrides option is the same
- [x] merge annotations
- [x] tests

takes:

![out2](https://cloud.githubusercontent.com/assets/1377/11356255/f163e6da-9210-11e5-939e-bc7d06c7b25c.png)

and makes it:

![out10](https://cloud.githubusercontent.com/assets/1377/11356265/12f66a8e-9211-11e5-9e67-7d7582328891.png)


this particular test has to much noise to verify the performance characteristics. I'll try to clean it up yet.

