### PR TITLE
single input, doesn’t require merge.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ module.exports = BroccoliMergeTrees
 BroccoliMergeTrees.prototype = Object.create(Plugin.prototype)
 BroccoliMergeTrees.prototype.constructor = BroccoliMergeTrees
 function BroccoliMergeTrees(inputNodes, options) {
+  if (Array.isArray(inputNodes) && inputNodes.length === 1) {
+    return inputNodes[0];
+  }
+
   if (!(this instanceof BroccoliMergeTrees)) return new BroccoliMergeTrees(inputNodes, options)
   options = options || {}
   var name = 'broccoli-merge-trees:' + (options.annotation || '')

--- a/test.js
+++ b/test.js
@@ -49,6 +49,11 @@ describe('MergeTrees', function() {
     });
   });
 
+  it('merge of 1 tree is an identity', function() {
+    var foo = {};
+    expect(new MergeTrees([foo])).to.eql(foo);
+  });
+
   it('merges files', function() {
     return expect(mergeFixtures([
       {
@@ -61,7 +66,6 @@ describe('MergeTrees', function() {
       baz: '2'
     })
   })
-
 
   it('merges empty directories', function() {
     return expect(mergeFixtures([


### PR DESCRIPTION
on very large programmatically built trees, this helps quite a-bit.