### PR TITLE
[Fix #50] Handle directory changes correctly

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -39,7 +39,7 @@
     "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
                                  // (ex: `for each`, multiple try/catch, function expression…)
     "evil"          : true,      // true: Tolerate use of `eval` and `new Function()`
-    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+    "expr"          : true,     // true: Tolerate `ExpressionStatement` as Programs
     "funcscope"     : false,     // true: Tolerate defining variables inside control statements"
     "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
     "iterator"      : false,     // true: Tolerate using the `__iterator__` property

--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ BroccoliMergeTrees.prototype.build = function() {
 }
 
 BroccoliMergeTrees.prototype._applyPatch = function (patch, instrumentation) {
+
   patch.forEach(function(patch) {
     var operation = patch[0];
     var relativePath = patch[1];
@@ -172,7 +173,9 @@ BroccoliMergeTrees.prototype._applyChange = function (entry, inputFilePath, outp
       // we don't check for `canSymlink` here because that is handled in
       // `isLinkStateEqual`.  If symlinking is not supported we will not get
       // directory change operations
-      return fs.unlinkSync(outputFilePath);
+      fs.unlinkSync(outputFilePath);
+      fs.mkdirSync(outputFilePath);
+      return
     }
   } else {
     // file changed

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "broccoli-plugin": "^1.0.0",
     "can-symlink": "^1.0.0",
     "fast-ordered-set": "^1.0.2",
-    "fs-tree-diff": "^0.5.2",
+    "fs-tree-diff": "^0.5.4",
     "heimdalljs": "^0.2.1",
     "heimdalljs-logger": "^0.1.7",
     "rimraf": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,13 @@
     "symlink-or-copy": "^1.0.0"
   },
   "devDependencies": {
+    "broccoli-builder": "^0.18.0",
     "broccoli-fixture": "^0.1.0",
     "chai": "^3.4.0",
     "chai-as-promised": "^5.1.0",
+    "chai-files": "^1.4.0",
+    "fixturify": "^0.3.1",
+    "fs-extra": "^1.0.0",
     "mocha": "^2.3.3",
     "mocha-jshint": "^2.2.5"
   },


### PR DESCRIPTION
Actually handle the symlink -> merge directory case.

When this occurs we're processing a change dir op.  Previously we were correctly removing the symlink, but we would fail to then create the actual directory!

Note that this depends on https://github.com/stefanpenner/fs-tree-diff/pull/39

- [ ] update to use new fs-tree-diff after https://github.com/stefanpenner/fs-tree-diff/pull/39 merged