### PR TITLE
build adds input nodes to error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function BroccoliMergeTrees(inputNodes, options) {
     needsCache: false,
     annotation: options.annotation
   });
+  this.inputNodes = inputNodes;
   this.options = options;
 }
 
@@ -31,5 +32,15 @@ BroccoliMergeTrees.prototype.build = function() {
     });
   }
 
-  this.mergeTrees.merge();
+  try {
+    this.mergeTrees.merge();
+  } catch(err) {
+    if (err !== null && typeof err === 'object') {
+      let nodesList = this.inputNodes.map((node, i) => `  ${i+1}.  ${node.toString()}`).join('\n');
+      let message = `${this.toString()} error while merging the following:\n${nodesList}`;
+
+      err.message = `${message}\n${err.message}`;
+    }
+    throw err;
+  }
 };

--- a/test.js
+++ b/test.js
@@ -26,6 +26,26 @@ describe('MergeTrees', function() {
       baz: {}
     });
   });
+
+  it('gives a useful error when merged trees have collisions', function () {
+    return mergeFixtures([
+      {
+        foo: 'hello',
+      }, {
+        foo: 'morehello',
+      }
+    ]).then(v => {
+      throw Error(`Should not fulfill ${v}`);
+    }, err => {
+      // append input nodes' names
+      expect(err.message).to.contain('[BroccoliMergeTrees] error while merging the following');
+      expect(err.message).to.contain('  1.  [Fixturify]');
+      expect(err.message).to.contain('  2.  [Fixturify]');
+
+      // wrap existing message
+      expect(err.message).to.contain('Merge error: file foo exists in');
+    });
+  });
 });
 
 


### PR DESCRIPTION
When `mergeTrees.merge()` throws an error, prepend that error message with the `toString` of our input nodes to aid debugging.

paired with @stefanpenner 