### PR TITLE
Passing the this.output as a customFS

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,9 +23,13 @@ class BroccoliMergeTrees extends Plugin {
     if (this.mergeTrees == null) {
       // Defer instantiation until the first build because we only
       // have this.inputPaths and this.outputPath once we build.
+
       this.mergeTrees = new MergeTrees(this.inputPaths, this.outputPath, {
         overwrite: this.options.overwrite,
-        annotation: this.options.annotation
+        annotation: this.options.annotation,
+        _fsUpdaterOptions: {
+          fs: this.output
+        }
       });
     }
 


### PR DESCRIPTION
* Depends on https://github.com/broccolijs/node-fs-updater/pull/2
* fs-facade change in broccoli-plugin needs to be passed to `node-fs-updater` as a custom fs method so that we can allow write operations to be passed through the encapsulation. 